### PR TITLE
Fixed Compilation Issue at 2025

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -24,7 +24,7 @@ opts.Add('CXX', 'The C++ compiler.')
 
 env = Environment(options = opts, ENV = os.environ, CCFLAGS = ' -Wall')
 
-env['platform'] = _platform.system().lower();
+env['platform'] = _platform.system().lower()
 env["CC"] = os.getenv("CC") or env["CC"]
 env["CXX"] = os.getenv("CXX") or env["CXX"]
 env["ENV"].update(x for x in os.environ.items() if x[0].startswith("CCC_"))
@@ -44,9 +44,9 @@ Help("""
 *** General options
 """ + opts.GenerateHelpText(env))
 
-print "===================================================="
-print "Compiling Netsukuku for " + env['platform']
-print "===================================================="
+print("====================================================")
+print("Compiling Netsukuku for " + env['platform'])
+print("====================================================")
 
 Export("env")
 

--- a/SConstruct
+++ b/SConstruct
@@ -22,16 +22,20 @@ opts.AddVariables(('CONF_DIR', """Directory where the Netsukuku configuration fi
 opts.Add('CC', 'The C compiler.')
 opts.Add('CXX', 'The C++ compiler.')
 
-env = Environment(options = opts, ENV = os.environ, CCFLAGS = ' -Wall')
+env = Environment(options=opts, ENV=os.environ, CCFLAGS=' -Wall')
+
+# Added       flag -fcommon for multiple definition of variables
+env.Append(CFLAGS=['-fcommon'])     # Per il codice C
+env.Append(CXXFLAGS=['-fcommon'])  # Per il codice C++
 
 env['platform'] = _platform.system().lower()
 env["CC"] = os.getenv("CC") or env["CC"]
 env["CXX"] = os.getenv("CXX") or env["CXX"]
 env["ENV"].update(x for x in os.environ.items() if x[0].startswith("CCC_"))
 
-env.Append(CPPPATH = ['#src'])
-env.Append(LIBPATH = ['#src'])
-env.Append(CFLAGS = ['-g'])
+env.Append(CPPPATH=['#src'])
+env.Append(LIBPATH=['#src'])
+env.Append(CFLAGS=['-g'])
 
 opts.Save('build.conf', env)
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -2,7 +2,7 @@
 # (c) Copyright 2005 Andrea Lo Pumo aka AlpT <alpt@freaknet.org>
 #
 # This source code is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Public License as published 
+# modify it under the terms of the GNU Public License as published
 # by the Free Software Foundation; either version 2 of the License,
 # or (at your option) any later version.
 #
@@ -23,147 +23,147 @@ Import("env")
 NTK_VERSION="0.0.9b"
 
 #
-#	Sources and libs
+#       Sources and libs
 #
 
 sources_common    = ['xmalloc.c', 'log.c', 'misc.c', 'buffer.c', 'endianness.c']
 
 sources_qspn      = ['qspn-empiric.c'] + sources_common
 sources_netsukuku = ['accept.c', 'llist.c', 'ipv6-gmp.c', 'inet.c', 'request.c',
-					 'map.c', 'gmap.c', 'bmap.c', 'pkts.c', 'radar.c', 'hook.c',
-					 'rehook.c', 'tracer.c', 'qspn.c', 'hash.c', 'daemon.c',
-					 'crypto.c', 'snsd_cache.c', 'andna_cache.c', 'andna.c',
-					 'andns_lib.c', 'err_errno.c', 'dnslib.c', 'andns.c',
-					 'andns_net.c', 'andns_snsd.c', 'll_map.c', 'libnetlink.c',
-					 'if.c', 'krnl_route.c', 'krnl_rule.c', 'iptunnel.c',
-					 'route.c', 'conf.c', 'dns_wrapper.c', 'igs.c', 'mark.c',
-					 'libiptc/libip4tc.c', 'libping.c', 'ntk-console-server.c',
-					 'netsukuku.c'] + sources_common
+                                         'map.c', 'gmap.c', 'bmap.c', 'pkts.c', 'radar.c', 'hook.c',
+                                         'rehook.c', 'tracer.c', 'qspn.c', 'hash.c', 'daemon.c',
+                                         'crypto.c', 'snsd_cache.c', 'andna_cache.c', 'andna.c',
+                                         'andns_lib.c', 'err_errno.c', 'dnslib.c', 'andns.c',
+                                         'andns_net.c', 'andns_snsd.c', 'll_map.c', 'libnetlink.c',
+                                         'if.c', 'krnl_route.c', 'krnl_rule.c', 'iptunnel.c',
+                                         'route.c', 'conf.c', 'dns_wrapper.c', 'igs.c', 'mark.c',
+                                         'libiptc/libip4tc.c', 'libping.c', 'ntk-console-server.c',
+                                         'netsukuku.c'] + sources_common
 sources_ntkresolv = ['andns_lib.c', 'andns_net.c', 'crypto.c', 'snsd_cache.c',
-					 'inet.c', 'll_map.c', 'libnetlink.c', 'err_errno.c',
-					 'ntkresolv.c'] + sources_common
+                                         'inet.c', 'll_map.c', 'libnetlink.c', 'err_errno.c',
+                                         'ntkresolv.c'] + sources_common
 
 sources_ntkconsole = ['ntk-console.c']
 
 libs = ['gmp', 'pthread', 'crypto', 'z']
 
 if ("yes" in env['debug']) or ("1" in env['debug']):
-	debug = 1
-	env.Append(CPPDEFINES={'DEBUG' : '${debug}'}, CCFLAGS = ' -ggdb -Wall', CXXFLAGS = '-g')
+        debug = 1
+        env.Append(CPPDEFINES={'DEBUG' : '${debug}'}, CCFLAGS = ' -ggdb -Wall', CXXFLAGS = '-g')
 #CCFLAGS = ' -ggdb -Wall -DDMALLOC_FUNC_CHECK'
-#	libs+=['dmalloc', 'dmallocth']
-	os.system("echo Cscoping and ctagging...; cscope -b; ctags *")
+#       libs+=['dmalloc', 'dmallocth']
+        os.system("echo Cscoping and ctagging...; cscope -b; ctags *")
 else:
-	debug  = 0
+        debug  = 0
 if ("yes" in env['static']) or ("1" in env['static']):
-	static = 1
-	env.Append(CCFLAGS = ' -static', CXXFLAGS = '-static')
+        static = 1
+        env.Append(CCFLAGS = ' -static', CXXFLAGS = '-static')
 else:
-	static = 0
+        static = 0
 if (env['destdir'] == "/"):
-	env['destdir']=""
+        env['destdir']=""
 
 if os.path.exists("conf/netsukuku.conf") and env.GetOption('clean'):
-	Execute(Delete('conf/netsukuku.conf'))
+        Execute(Delete('conf/netsukuku.conf'))
 if os.path.exists("config.h") and env.GetOption('clean'):
-	Execute(Delete('config.h'))
+        Execute(Delete('config.h'))
 if os.path.exists("config.log") and env.GetOption('clean'):
-	Execute(Delete('config.log'))
-	
+        Execute(Delete('config.log'))
+
 if ARGUMENTS.get('install'):
-		print "you aren't root"
+                print("you aren't root")
 
 #
-#	Configure
+#       Configure
 #
 
 if not os.path.exists("config.log") and not env.GetOption('clean'):
-	print 'Configuring... '
-	conf = Configure(env)
-	if not conf.CheckLib('gmp'): 
-		print 'Did not find libgmp.a or gmp.lib, exiting!'
-		Execute(Delete('config.log'))
-		Exit(1)
-	if not conf.CheckCHeader([ "gmp.h" ]):
-		print 'Did not find the gmp headers, exiting!'
-		Execute(Delete('config.log'))
-		Exit(1)
-	if not conf.CheckCHeader([ "zlib.h" ]):
-		print 'Did not find the zlib headers, exiting!'
-		Execute(Delete('config.log'))
-		Exit(1)
-	if not conf.CheckLib('pthread'):
-       		print 'Did not find pthread.a or pthread.lib, exiting!'
-		Execute(Delete('config.log'))
-		Exit(1)
-	if not conf.CheckLib('crypto'): 
-		print 'Did not find the openssl libcrypto.a or libcrypto.lib, exiting!'
-		Execute(Delete('config.log'))
-		Exit(1)
-	if not conf.CheckCHeader([ "openssl/bio.h", "openssl/evp.h",
-			"openssl/crypto.h", "openssl/x509.h",
-			"openssl/engine.h", "openssl/err.h", "openssl/rand.h",
-			"openssl/rsa.h", "openssl/pem.h" ]):
-		print 'Did not find the openssl headers, exiting!'
-		Execute(Delete('config.log'))
-		Exit(1)
-		
-	env = conf.Finish()
+        print("Configuring... ")
+        conf = Configure(env)
+        if not conf.CheckLib('gmp'):
+                print("Did not find libgmp.a or gmp.lib, exiting!")
+                Execute(Delete('config.log'))
+                Exit(1)
+        if not conf.CheckCHeader([ "gmp.h" ]):
+                print("Did not find the gmp headers, exiting!")
+                Execute(Delete('config.log'))
+                Exit(1)
+        if not conf.CheckCHeader([ "zlib.h" ]):
+                print("Did not find the zlib headers, exiting!")
+                Execute(Delete('config.log'))
+                Exit(1)
+        if not conf.CheckLib('pthread'):
+                print("Did not find pthread.a or pthread.lib, exiting!")
+                Execute(Delete('config.log'))
+                Exit(1)
+        if not conf.CheckLib('crypto'):
+                print("Did not find the openssl libcrypto.a or libcrypto.lib, exiting!")
+                Execute(Delete('config.log'))
+                Exit(1)
+        if not conf.CheckCHeader([ "openssl/bio.h", "openssl/evp.h",
+                        "openssl/crypto.h", "openssl/x509.h",
+                        "openssl/engine.h", "openssl/err.h", "openssl/rand.h",
+                        "openssl/rsa.h", "openssl/pem.h" ]):
+                print("Did not find the openssl headers, exiting!")
+                Execute(Delete('config.log'))
+                Exit(1)
+
+        env = conf.Finish()
 
 def conf_build(target, source, env):
     conf_defines = {
-		"CONF_DIR": env["CONF_DIR"],
-		"DATA_DIR": env["DATA_DIR"],
-		"PID_DIR": env["PID_DIR"],
-		"VERSION": NTK_VERSION,
+                "CONF_DIR": env["CONF_DIR"],
+                "DATA_DIR": env["DATA_DIR"],
+                "PID_DIR": env["PID_DIR"],
+                "VERSION": NTK_VERSION,
         "debug": debug # this is an int.  1 for true, 0 for false
     }
 
-    conf = file(str(target), "w")
-    conf_in = file(str(source), "r")
+    conf = open(str(target), "w")
+    conf_in = open(str(source), "r")
     conf.write(conf_in.read() % conf_defines)
     conf_in.close()
     conf.close()
 
 def build_config_files(target = None, source = None, env = None):
-	if not os.path.exists("config.h") and not env.GetOption('clean'):
-		print 'Generating config.h from config_scons.h.in'
-		conf_build('config.h', 'config_scons.h.in', env)
-		conf = file("config.h", "a")
-		if sys.platform == 'linux2' or sys.platform == 'linux-i386':
-			conf.write("#define GNU_LINUX\n")
-		elif sys.platform == 'darwin':
-			conf.write("#define DARWIN\n")
-		elif string.find (sys.platform, 'sunos') != -1:
-			conf.write("#define SUNOS\n")
-		elif sys.platform=='openbsd3':
-			conf.write("#define OPEN_BSD\n")
-		elif string.find (sys.platform, 'irix') != -1:
-			conf.write("#define IRIX\n")
-		conf.close()
+        if not os.path.exists("config.h") and not env.GetOption('clean'):
+                print("Generating config.h from config_scons.h.in")
+                conf_build('config.h', 'config_scons.h.in', env)
+                conf = open("config.h", "a")
+                if sys.platform == 'linux2' or sys.platform == 'linux-i386':
+                        conf.write("#define GNU_LINUX\n")
+                elif sys.platform == 'darwin':
+                        conf.write("#define DARWIN\n")
+                elif 'sunos' in sys.platform:
+                        conf.write("#define SUNOS\n")
+                elif sys.platform == 'openbsd3':
+                        conf.write("#define OPEN_BSD\n")
+                elif 'irix' in sys.platform:
+                        conf.write("#define IRIX\n")
+                conf.close()
 
-	if not os.path.exists("conf/netsukuku.conf") and not env.GetOption('clean'):
-		print 'Generating conf/netsukuku.conf from conf/ntk_scons.conf.in'
-		conf_build('conf/netsukuku.conf', 'conf/ntk_scons.conf.in', env)
-	
-	return 0
+        if not os.path.exists("conf/netsukuku.conf") and not env.GetOption('clean'):
+                print("Generating conf/netsukuku.conf from conf/ntk_scons.conf.in")
+                conf_build('conf/netsukuku.conf', 'conf/ntk_scons.conf.in', env)
+
+        return 0
 
 build_config_files(env = env)
 
 #
-#	Build
+#       Build
 #
 
-ntkd 		= env.Program('ntkd', sources_netsukuku, LIBS = libs, CPPPATH = '.')
-qspn  		= env.Program('qspn-empiric', sources_qspn, LIBS = libs, CPPPATH = '.')
-ntkresolv 	= env.Program('ntk-resolv', sources_ntkresolv, LIBS = libs, CPPPATH = '.')
-ntkconsole 	= env.Program('ntk-console', sources_ntkconsole, LIBS = libs, CPPPATH = '.', CFLAGS = '-std=c99')
+ntkd            = env.Program('ntkd', sources_netsukuku, LIBS = libs, CPPPATH = '.')
+qspn            = env.Program('qspn-empiric', sources_qspn, LIBS = libs, CPPPATH = '.')
+ntkresolv       = env.Program('ntk-resolv', sources_ntkresolv, LIBS = libs, CPPPATH = '.')
+ntkconsole      = env.Program('ntk-console', sources_ntkconsole, LIBS = libs, CPPPATH = '.', CFLAGS = '-std=c99')
 
 Default(ntkd, ntkresolv, ntkconsole, qspn)
 
 
 #
-#	Install 
+#       Install
 #
 
 SConscript(['man/SConscript', 'scripts/SConscript', 'conf/SConscript'], 'env')
@@ -181,4 +181,4 @@ env.Alias('install', [idir_bin, idir_conf])
 
 #Dirty hack ;( Why GetOption("install") doesn't work?
 #if not os.path.exists(env["DATA_DIR"]) and os.path.exists(env["CONF_DIR"]):
-#	Execute(Mkdir(env["DATA_DIR"]))
+#       Execute(Mkdir(env["DATA_DIR"]))


### PR DESCRIPTION
This change resolves compilation issues related to multiple definitions of global variables, caused by the default behavior of GCC starting from version 10, which uses the -fno-common flag by default.

Details of the Changes
Addition of the -fcommon flag:

Modified the SConstruct script to add the -fcommon flag to the compilation options.
Specific application:
CFLAGS: Used for code written in C.
CXXFLAGS: Used for code written in C++.